### PR TITLE
Debug/amalbuildunittest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,15 @@ unittest: debug
 	build/debug/test/unittest
 	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
 
+unittestamalcapicomplete:
+	amaldebug
+	build/amaldebug/test/unittest "[capi]"
+	build/amaldebug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
+
+unittestamalcapi:
+	build/amaldebug/test/unittest "[capi]"
+	build/amaldebug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
+
 unittestci:
 	python3 scripts/run_tests_one_by_one.py build/debug/test/unittest
 	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,10 @@ unittestamalcapi:
 	build/amaldebug/test/unittest "[capi]"
 	build/amaldebug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
 
+unittestcapi:
+	build/debug/test/unittest "[capi]"
+	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
+
 unittestci:
 	python3 scripts/run_tests_one_by_one.py build/debug/test/unittest
 	build/debug/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper


### PR DESCRIPTION
Some Makefile commands and a special test that triggers a behavior we see with decimals. The problem is due to the amalgamation build and is due to some templating issues.

My `.vscode/launch.json` config is:

```
{
    "configurations": [
      {
        "name": "Debug unit test amal [amal]",
        "type": "lldb",
        "request": "launch",
        "program": "${workspaceFolder}/build/amaldebug/test/unittest",
        "args": ["[amal]"],
        "cwd": "${workspaceFolder}"
      },
      {
        "name": "Debug unit test normal [amal]",
        "type": "lldb",
        "request": "launch",
        "program": "${workspaceFolder}/build/debug/test/unittest",
        "args": ["[amal]"],
        "cwd": "${workspaceFolder}"
      }
    ]
  }
 ```
 
 I'm using the [Codelldb](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension for vscode as I'm on an M1.